### PR TITLE
Bluebutton 1254 oauth2 urls

### DIFF
--- a/apps/dot_ext/urls.py
+++ b/apps/dot_ext/urls.py
@@ -20,7 +20,7 @@ management_urlpatterns = [
     url(r"^applications/$", oauth2_views.ApplicationList.as_view(), name="list"),
     url(r"^applications/register/$", views.ApplicationRegistration.as_view(), name="register"),
     url(r"^applications/(?P<pk>[\w-]+)/$", oauth2_views.ApplicationDetail.as_view(), name="detail"),
-    url(r"^applications/(?P<pk>[\w-]+)/delete/$", oauth2_views.ApplicationDelete.as_view(), name="delete"),
+    url(r"^applications/(?P<pk>[\w-]+)/delete/$", views.ApplicationDelete.as_view(), name="delete"),
     url(r"^applications/(?P<pk>[\w-]+)/update/$", views.ApplicationUpdate.as_view(), name="update"),
     # Token management views
     url(r"^authorized_tokens/$", oauth2_views.AuthorizedTokensListView.as_view(), name="authorized-token-list"),

--- a/apps/dot_ext/urls.py
+++ b/apps/dot_ext/urls.py
@@ -1,14 +1,32 @@
 from django.conf.urls import include, url
+from oauth2_provider import views as oauth2_views
 from . import views
 
-oauth2_provider_urls = ([
-    url(r'^applications/register/$', views.ApplicationRegistration.as_view(), name="register"),
-    url(r'^applications/(?P<pk>\d+)/update/$', views.ApplicationUpdate.as_view(), name="update"),
+
+app_name = "oauth2_provider"
+
+
+base_urlpatterns = [
     url(r'^authorize/$', views.AuthorizationView.as_view(), name="authorize"),
     url(r'^authorize/(?P<uuid>[\w-]+)/$', views.ApprovalView.as_view(), name="authorize-instance"),
-], 'dot_ext')
-
-urlpatterns = [
-    url(r'', include(oauth2_provider_urls)),
-    url(r'', include('oauth2_provider.urls')),
+    url(r"^token/$", oauth2_views.TokenView.as_view(), name="token"),
+    url(r"^revoke_token/$", oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
+    url(r"^introspect/$", oauth2_views.IntrospectTokenView.as_view(), name="introspect"),
 ]
+
+
+management_urlpatterns = [
+    # Application management views
+    url(r"^applications/$", oauth2_views.ApplicationList.as_view(), name="list"),
+    url(r"^applications/register/$", views.ApplicationRegistration.as_view(), name="register"),
+    url(r"^applications/(?P<pk>[\w-]+)/$", oauth2_views.ApplicationDetail.as_view(), name="detail"),
+    url(r"^applications/(?P<pk>[\w-]+)/delete/$", oauth2_views.ApplicationDelete.as_view(), name="delete"),
+    url(r"^applications/(?P<pk>[\w-]+)/update/$", views.ApplicationUpdate.as_view(), name="update"),
+    # Token management views
+    url(r"^authorized_tokens/$", oauth2_views.AuthorizedTokensListView.as_view(), name="authorized-token-list"),
+    url(r"^authorized_tokens/(?P<pk>[\w-]+)/delete/$", oauth2_views.AuthorizedTokenDeleteView.as_view(),
+        name="authorized-token-delete"),
+]
+
+
+urlpatterns = base_urlpatterns + management_urlpatterns

--- a/apps/dot_ext/views/__init__.py
+++ b/apps/dot_ext/views/__init__.py
@@ -1,2 +1,2 @@
-from .application import ApplicationRegistration, ApplicationUpdate  # NOQA
+from .application import ApplicationRegistration, ApplicationUpdate, ApplicationDelete  # NOQA
 from .authorization import AuthorizationView, ApprovalView  # NOQA

--- a/apps/dot_ext/views/application.py
+++ b/apps/dot_ext/views/application.py
@@ -1,3 +1,4 @@
+from django.urls import reverse_lazy
 from oauth2_provider import views as oauth2_views
 
 from ..forms import CustomRegisterApplicationForm
@@ -36,3 +37,8 @@ class ApplicationUpdate(CustomFormMixin, oauth2_views.ApplicationUpdate):
         Returns the form class for the application model
         """
         return CustomRegisterApplicationForm
+
+
+class ApplicationDelete(oauth2_views.ApplicationDelete):
+    
+    success_url= reverse_lazy("home")

--- a/apps/home/urls.py
+++ b/apps/home/urls.py
@@ -5,6 +5,6 @@ from .views import AuthenticatedHomeView, HomeView
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'home', AuthenticatedHomeView.as_view(), name='auth_home'),
-    url(r'', HomeView.as_view(), name='auth_home'),
+    url(r'home', AuthenticatedHomeView.as_view(), name='home'),
+    url(r'', HomeView.as_view(), name='unauth_home'),
 ]

--- a/apps/mymedicare_cb/tests/test_callback.py
+++ b/apps/mymedicare_cb/tests/test_callback.py
@@ -56,7 +56,7 @@ class MyMedicareBlueButtonClientApiUserInfoTest(TestCase):
 
     def test_authorize_uuid_dne(self):
         auth_uri = reverse(
-            'dot_ext:authorize-instance',
+            'oauth2_provider:authorize-instance',
             args=[uuid.uuid4()])
         response = self.client.get(auth_uri)
         self.assertEqual(302, response.status_code)
@@ -100,7 +100,7 @@ class MyMedicareBlueButtonClientApiUserInfoTest(TestCase):
         approval = Approval.objects.create(
             user=user)
         auth_uri = reverse(
-            'dot_ext:authorize-instance',
+            'oauth2_provider:authorize-instance',
             args=[approval.uuid])
         response = self.client.get(auth_uri, data={
             "client_id": application.client_id,

--- a/apps/mymedicare_cb/views.py
+++ b/apps/mymedicare_cb/views.py
@@ -94,7 +94,7 @@ def callback(request):
         user=request.user)
 
     # Only go back to app authorization
-    auth_uri = reverse('dot_ext:authorize-instance', args=[approval.uuid])
+    auth_uri = reverse('oauth2_provider:authorize-instance', args=[approval.uuid])
     _, _, auth_path, _, _ = urlsplit(auth_uri)
 
     return HttpResponseRedirect(urlunsplit((scheme, netloc, auth_path, query_string, fragment)))


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details

oauth2 resource urls are exposed to the developer and placed under the `oauth2_provider` namespace.

ApplicationDelete behavior has been overridden to redirect `home`
<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation

<!-- What should reviewers look for to determine completeness -->
- Does the delete redirect work (or look like it works) correctly?
- Is having the urls brought into the light help make this more understandable/maintainable?
<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

is having the custom behavior (`authorize-instance`) under the `oauth2_provider` namespace confusing?
<!-- What type of feedback you want from your reviewers? -->

